### PR TITLE
Add descriptions for sections

### DIFF
--- a/docs/chain/_category_.json
+++ b/docs/chain/_category_.json
@@ -3,6 +3,6 @@
   "position": 4,
   "link": {
     "type": "generated-index",
-    "description": "Documentation related to Madara components."
+    "description": "This section provides resources to learn about different Madara components. It start with an overview and an architectural and later expands into deep-dive component documentation."
   }
 }

--- a/docs/quickstart/_category_.json
+++ b/docs/quickstart/_category_.json
@@ -2,6 +2,7 @@
   "label": "Quickstart",
   "position": 3,
   "link": {
-    "type": "generated-index"
+    "type": "generated-index",
+    "description": "This section provides quick-start guides to get you started with Madara."
   }
 }


### PR DESCRIPTION
Add a bit more information for the different section front pages.

The text is only meant to be one paragraph. Mostly it seems to be just one sentence in other documentations. Even a really simple one sometimes: 
![image](https://github.com/user-attachments/assets/8a1409cc-8683-4b4f-a267-75779d07929e)


This is related to https://github.com/walnuthq/madara-docs/issues/15