### PR TITLE
Remove L2/L3 from chain component overview

### DIFF
--- a/docs/chain/overview.md
+++ b/docs/chain/overview.md
@@ -7,9 +7,3 @@ sidebar_position: 1
 A chain operator is responsible for running and maintaining a Madara blockchain. A new blockchain can be started simply by becoming the first chain operator for a network.
 
 Chain operator's responsibilities include configuring their part of the network, making sure the necessary components are running and managing interoperability with external components.
-
-## Layer 2 or Layer 3
-
-Madara can launch either a Starknet clone (a L2 network) or a new network on top of a Starknet network, which is also called an Application Chain (App Chain or L3). The basic functionality remains mostly the same, the main difference is the settlement layer.
-
-


### PR DESCRIPTION
Remove the comparison.

The page is a little bit empty, but easier to add things later and better to remove unwanted stuff fast.