### PR TITLE
Make light/dark theme respect computer default

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -174,6 +174,9 @@ const config: Config = {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
     },
+    colorMode: {
+      respectPrefersColorScheme: true, // Enables system preference
+    },
   } satisfies Preset.ThemeConfig,
 };
 


### PR DESCRIPTION
Add a setting that should make the docs respect the computer's default theme.

This resolves #33 