### PR TITLE
Fix local chain startup wording

### DIFF
--- a/docs/quickstart/run_localchain.md
+++ b/docs/quickstart/run_localchain.md
@@ -41,6 +41,6 @@ The above will prompt you for various options. You should choose the following:
 1. Select Madara mode: `Devnet`. This is a local chain
 1. Input DB path: keep the default
 
-It may take half an hour to prepare the image for the first time. Once the local chain is ready, leave it running and open a new terminal for the rest of this guide.
+It may take half an hour to prepare the image for the first time. Wait for that to finish.
 
-Congratulations, you now have a fully functioning local chain running! Next, you may want to [interact](use_localchain) with the chain.
+After that, congratulations, you now have a fully functioning local chain running! Next, you may want to [interact](use_localchain) with the chain.

--- a/docs/quickstart/run_localchain.md
+++ b/docs/quickstart/run_localchain.md
@@ -43,4 +43,4 @@ The above will prompt you for various options. You should choose the following:
 
 It may take half an hour to prepare the image for the first time. Wait for that to finish.
 
-After that, congratulations, you now have a fully functioning local chain running! Next, you may want to [interact](use_localchain) with the chain.
+Congratulations, you now have a fully functioning local chain running! Next, you may want to [interact](use_localchain) with the chain.


### PR DESCRIPTION
It makes no sense to talk about "the rest of this guide" since the guide ends here.

Fix the wording.