### PR TITLE
Remove note about double installation

### DIFF
--- a/docs/quickstart/use_localchain.md
+++ b/docs/quickstart/use_localchain.md
@@ -18,7 +18,6 @@ Start by installing the specific tooling used in this tutorial (answer yes if it
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.starkup.dev | sh
 ```
-Because of temporary issues in the tool's installation, you now have to restart your terminal and run the same installation command again.
 
 The above will install [Starkup](https://github.com/software-mansion/starkup), a toolchain to help with Starknet development. Now restart your terminal again to reload new environment variables.
 


### PR DESCRIPTION
In an earlier version of Starkup, one needed to run the installation script twice. A new version was released today which removes this requirement.

Fixed docs accordingly.

This resolves https://github.com/walnuthq/madara-docs/issues/77