### PR TITLE
Add 'no disk' error resolution

### DIFF
--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 draft: true
 ---
 

--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 8
+draft: true
+---
+
+# Troubleshooting
+
+<p>Problem: `No space left on devide` when trying to install Madara</p>
+<p>Answer: Make sure you have enough disk space left. If that is not an issue, please check your Docker configuration that you have allowed enough memory and hard disk for the images.</p>


### PR DESCRIPTION
Add a draft page: it won't be public before the draft status is removed.

This is currently mostly a placeholder for whatever problems we encounter. We can publish it once there is enough content.