### PR TITLE
Add ignore for tooling versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ website/i18n/**/*
 #!website/i18n/fr/**/*
 
 .netlify
+.tool-versions


### PR DESCRIPTION
Add a git ignore for a file that specifies used tooling versions.

The docs project really doesn't need any of these tools, but while testing Madara so one can write docs, various tooling is required. No point in adding the tooling info in the repo itself - that's why the file is being set to ignore.