### PR TITLE
Centralize installations

### DIFF
--- a/docs/quickstart/bridge_appchain.md
+++ b/docs/quickstart/bridge_appchain.md
@@ -18,12 +18,6 @@ A *bridge* is the solution for bridging. Often it has a website users can use. I
 
 Bridging can happen in either direction. The exact mechanisms may differ, but the end result is very similar: your asset gets transferred to the other side of the bridge.
 
-## Installation
-
-The needed tooling depends on which direction you want to bridge:
-- If you want to bridge from the settlement layer to the Appchain, install [Foundry](https://book.getfoundry.sh/getting-started/installation).
-- If you want to bridge from the Appchain to the settlement layer, install both [Foundry](https://book.getfoundry.sh/getting-started/installation) and [Starknet Foundry](https://foundry-rs.github.io/starknet-foundry/getting-started/installation.html).
-
 ## What to bridge
 
 The used bridging solution, Starkgate, supports multiple tokens. It's also possible to bridge the native asset (Eth).

--- a/docs/quickstart/monitor_appchain.md
+++ b/docs/quickstart/monitor_appchain.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 20
 ---
 
 # Monitor a running Appchain

--- a/docs/quickstart/prerequirements.md
+++ b/docs/quickstart/prerequirements.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 1
+---
+
+# Prerequisites
+
+Before following the guides in this documentation, ensure you have the necessary tooling installed.
+
+Please verify you all of have the following tools installed, or install them if needed.
+
+:::info
+These instructions assume you are using Linux or macOS. For Windows, please utilize [WSL2](https://learn.microsoft.com/en-us/windows/wsl/).
+:::
+
+## Compiler tools
+
+Ensure you have a C compiler (like gcc or clang) and `make` installed. Installation steps depend on your OS - please refer to your package manager or system documentation.
+
+### Why it's needed
+
+These tools are needed when building Madara from source code. This is currently the only option on how to run Madara.
+
+## Rust
+
+Please install Rust following [these](https://www.rust-lang.org/tools/install) instructions.
+
+### Why it's needed
+
+Most of Madara's code is written in Rust. Compiling Rust requires its toolchain.
+
+## Docker
+
+Please install Docker following [these](https://docs.docker.com/engine/install/) instructions.
+
+### Why it's needed
+
+Many of Madara's components are packaged into Docker images for easier execution. Docker tooling is required for utilizing these packages.
+
+## Foundry
+
+Please install Foundry following [these](https://book.getfoundry.sh/getting-started/installation) instructions.
+
+### Why it's needed
+
+Foundry is a toolchain for interacting with Ethereum smart contracts. All of the interactions related to Ethereum (Anvil) in these guides utilize Foundry.
+
+## Starkup
+
+Run the following in a terminal to install [Starkup](https://github.com/software-mansion/starkup):
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.starkup.dev | sh -s -- --yes
+```
+
+Now restart your terminal to take the tooling into use. Next, you have to set the correct versions that are compatible with Madara:
+```bash
+asdf install scarb 2.9.2
+asdf set scarb 2.9.2
+asdf install starknet-foundry 0.36.0
+asdf set starknet-foundry 0.36.0
+```
+### Why it's needed
+
+Starkup is an installer to help with Starknet development. The installed tools are:
+- [asdf](https://asdf-vm.com/), a runtime version manager. Used by many Starknet tools.
+- [Scarb](https://docs.swmansion.com/scarb/), a smart contract build toolchain and package manager.
+- [Starknet Foundry](https://foundry-rs.github.io/starknet-foundry/index.html), a Starknet smart contract development tool.
+
+The above tools are needed for interacting with Starknet-based Appchains, like Madara.

--- a/docs/quickstart/run_appchain.md
+++ b/docs/quickstart/run_appchain.md
@@ -47,7 +47,7 @@ cargo run create
 
 ### Step 3: Use Appchain mode
 
-The CLI will first ask you what Madara type to run. Since we want an Appchain, you should choose *Appchain*.
+The CLI will first ask you what Madara mode to run. Since we want an Appchain, you should choose *Appchain*.
 
 ### Step 4: Deploy L2 contracts
 

--- a/docs/quickstart/run_appchain.md
+++ b/docs/quickstart/run_appchain.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 7
 ---
 
 # Run a local appchain
@@ -16,15 +16,40 @@ An Appchain is a blockchain built for a single purpose. It runs all of the requi
 
 Furthermore, an Appchain is typically built on top of some existing blockchain. Madara's Appchains run on top of either Starknet or Ethereum and [settle](/concepts/settlement) their transactions there for added security.
 
+## Prerequisites
+
+Before starting, please make sure you have all of the [required tools](/tools) installed.
+
+Remember to also check the [hardware requirements](/hardware) to make sure you can run an Appchain properly.
+
 ## Run the appchain locally
 
-These instructions will walk you through setting up an Appchain. Please check the [hardware requirements](/hardware) to make sure you can run the Appchain properly.
+These instructions will walk you through setting up an Appchain.
 
-### Step 1: Install Madara CLI and run your Appchain
+### Step 1: Install Madara CLI
 
-Follow the [devnet](/quickstart/run_devnet) guide. After you run the CLI, you will be prompted for the "Madara mode". Instead of choosing `Devnet` choose `Appchain`.
+You should start by installing the main tool for running Madara, the Madara CLI:
+```bash
+git clone https://github.com/madara-alliance/madara-cli.git
+cd madara-cli
+git submodule update --init --recursive --jobs=4
+```
 
-### Step 2: Deploy L2 contracts
+The above will clone the repository into a new folder, enter the folder and initialize the repository's Git submodules.
+
+### Step 2: Start the runner
+
+Next, in the `madara-cli` folder, run the following to start the Madara runner:
+
+```bash
+cargo run create
+```
+
+### Step 3: Use Appchain mode
+
+The CLI will first ask you what Madara type to run. Since we want an Appchain, you should choose *Appchain*.
+
+### Step 4: Deploy L2 contracts
 
 The CLI will next ask whether you want to deploy initial contracts to the Appchain (L2). The contracts to be deployed are:
 - Contracts related to bridging.
@@ -33,7 +58,7 @@ The CLI will next ask whether you want to deploy initial contracts to the Appcha
 
 You should choose *Yes*.
 
-### Step 3: Select the prover
+### Step 5: Select the prover
 
 The CLI will next ask to choose the [prover](/components/prover). There are multiple options:
 
@@ -43,25 +68,25 @@ The CLI will next ask to choose the [prover](/components/prover). There are mult
 
 For now, select `Dummy`.
 
-### Step 4: Choose whether to use local images
+### Step 6: Choose whether to use local images
 
 Choosing *No* will download ready Docker images from a trusted registry. Choosing *Yes* builds the images locally - this can take quite some time.
 
 To get started quickly, you should choose *No*.
 
-### Step 5: Select the settlement layer (coming soon)
+### Step 7: Select the settlement layer (coming soon)
 
 When running your Appchain, selecting the settlement layer is an important consideration.
 
 At the moment, the CLI will automatically set up a new Ethereum chain (with Anvil) as the settlement layer. This will become customizable later.
 
-### Step 6: Wait for the Appchain to be configured
+### Step 8: Wait for the Appchain to be configured
 
-It will require 55 blocks (about 10 minutes) for the Appchain to be configured properly - you should wait for that before interacting with it.
+It will require about 55 blocks (about 10 minutes) for the Appchain to be configured properly - you should wait for that before interacting with it.
 
 ![Appchain is ready](/img/quickstart-appchain-ready.png "Appchain is ready")
 
-### Step 7: Your Appchain is ready
+### Step 9: Your Appchain is ready
 
 Congratulations, you now have your own Appchain running!
 

--- a/docs/quickstart/run_appchain.md
+++ b/docs/quickstart/run_appchain.md
@@ -39,7 +39,7 @@ The above will clone the repository into a new folder, enter the folder and init
 
 ### Step 2: Start the runner
 
-Next, in the `madara-cli` folder, run the following to start the Madara runner:
+Next, in the `madara-cli` folder, run the following command to start the Madara runner:
 
 ```bash
 cargo run create

--- a/docs/quickstart/run_devnet.md
+++ b/docs/quickstart/run_devnet.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 ---
 
 # Run a devnet
@@ -12,16 +12,9 @@ The chain is lightweight and does not settle its transactions on any underlying 
 
 ## Installation
 
-These installation instructions assume you are using Linux or macOS. For Windows, please utilize [WSL2](https://learn.microsoft.com/en-us/windows/wsl/).
+Before continuing, please see the [required tools](/tools) page about installing common tooling.
 
-### Prerequisites
-
-You will need to have the following system components installed:
-- Rust. Please see [here](https://www.rust-lang.org/tools/install) for instructions.
-- Docker. Please see [here](https://docs.docker.com/engine/install/) for instructions.
-- A C compiler (such as GCC or Clang) and `make`.
-
-### Install Madara CLI
+## Install Madara CLI
 
 You should start by installing the main tool for running Madara, the Madara CLI:
 ```bash

--- a/docs/quickstart/use_devnet.md
+++ b/docs/quickstart/use_devnet.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 5
 ---
 
 # Use a running devnet
@@ -7,28 +7,6 @@ sidebar_position: 2
 ## Overview
 
 This quick-start guide helps you interact with a devnet. Please make sure you are [running a Madara devnet](run_devnet) in a separate terminal before continuing.
-
-## Installation
-
-These installation instructions assume you are using Linux or macOS. For Windows, please utilize [WSL2](https://learn.microsoft.com/en-us/windows/wsl/).
-
-### Install tooling for interaction
-
-Start by installing the specific tooling used in this tutorial:
-```bash
-curl --proto '=https' --tlsv1.2 -sSf https://sh.starkup.dev | sh -s -- --yes
-```
-
-The above will install the required tooling with [Starkup](https://github.com/software-mansion/starkup), a toolchain to help with Starknet development. The installed tools are:
-- [asdf](https://asdf-vm.com/), a runtime version manager. Used by many Starknet tools.
-- [Scarb](https://docs.swmansion.com/scarb/), a build toolchain and package manager.
-- [Starknet Foundry](https://foundry-rs.github.io/starknet-foundry/index.html), a Starknet smart contract development tool.
-
-Now restart your terminal to take the tooling into use. Next, you have to set the correct versions that are compatible with Madara:
-```bash
-asdf install scarb 2.9.2
-asdf set scarb 2.9.2
-```
 
 ## Prepare your contract
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Prerequisites
+# Required tools
 
 Before following the guides in this documentation, ensure you have the necessary tooling installed.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -6,8 +6,6 @@ sidebar_position: 1
 
 Before following the guides in this documentation, ensure you have the necessary tooling installed.
 
-Please verify you all of have the following tools installed, or install them if needed.
-
 :::info
 These instructions assume you are using Linux or macOS. For Windows, please utilize [WSL2](https://learn.microsoft.com/en-us/windows/wsl/).
 :::
@@ -36,7 +34,7 @@ Please install Docker following [these](https://docs.docker.com/engine/install/)
 
 Many of Madara's components are packaged into Docker images for easier execution. Docker tooling is required for utilizing these packages.
 
-## Foundry
+## Ethereum Foundry
 
 Please install Foundry following [these](https://book.getfoundry.sh/getting-started/installation) instructions.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -14,6 +14,8 @@ These instructions assume you are using Linux or macOS. For Windows, please util
 
 Ensure you have a C compiler (like gcc or clang) and `make` installed. Installation steps depend on your OS - please refer to your package manager or system documentation.
 
+Most development environments come with these tools preinstalled.
+
 ### Why it's needed
 
 These tools are needed when building Madara from source code. This is currently the only option on how to run Madara.


### PR DESCRIPTION
- Add a centralized page for installation instructions
- Modify guides to use this tools page
- Modify guides to include more setup instructions instead of cross-links, to reduce cross-links
- Adjust page positions in the left sidebar

Questions:
- Is the location for the 'tools' page ok? It's very high in the left panel, but also it needs to be done before the guides. Or maybe it should be somewhere in the bottom, because guides will anyway link to it?

Here are the references between pages and tools before and after:
![image](https://github.com/user-attachments/assets/4f4e651d-dc2d-45d4-9d05-09cce2df6f0a)
