### PR TITLE
Small rewording and styling

### DIFF
--- a/docs/components/architecture.md
+++ b/docs/components/architecture.md
@@ -5,10 +5,10 @@ sidebar_position: 2
 # Architecture
 
 A Madara [Appchain](/concepts/appchain) consists of the following components:
-- An [orchestrator](/components/orchestrator)
-- A sequencer
-- Starknet OS (SNOS)
-- A prover
+- An [orchestrator](orchestrator)
+- A [sequencer](nodes)
+- [Starknet OS](starknet_os) (SNOS)
+- A [prover](prover)
 - A [settlement layer](/concepts/settlement)
 
 Note that some components are left out, for now, for simplicity.
@@ -38,8 +38,6 @@ sequenceDiagram
     participant SNOS as Starknet OS (SNOS)
     participant Prover
     participant Verifier as Settlement Layer
-
-    Note over Sequencer: Madara in Sequencer mode (Solo chain) does not need SNOS.
 
     Sequencer ->> Sequencer: Execute transactions & generate state diff
     Sequencer ->> Sequencer: Assemble block

--- a/docs/components/bootstrapper.md
+++ b/docs/components/bootstrapper.md
@@ -8,7 +8,7 @@ sidebar_position: 16
 
 Madara Bootstrapper helps you initialize the essential contracts on your [Appchain](/concepts/appchain) and its [settlement layer](/concepts/settlement).
 
-Without the bootstrapper, your Appchain starts as an empty network with no accounts or assets, making it unusable for transactions.
+Without the bootstrapper, your Appchain starts as an empty network with no class hashes or bridges, making it unusable for transactions.
 
 The bootstrapper deploys key contracts and configurations, allowing you to quickly start using your new Appchain. It only needs to be executed once per Appchain deployment.
 

--- a/docs/components/orchestrator.md
+++ b/docs/components/orchestrator.md
@@ -12,12 +12,11 @@ The orchestrator is a unique component in Madara [Appchains](/concepts/appchain)
 
 ## Responsibilities
 
-The orchestrator has four main responsibilities:
+The orchestrator has three main responsibilities:
 
-1. SNOS communication. Asks SNOS to process ready blocks and retrieve results.
-1. Proof coordination. Sends the required data to the prover and monitors for ready proofs.
-1. DA communication. Submits data for Data Availability Layer (currently Ethereum or Starknet).
-1. SL communication. Submits data for [Settlement Layer](/concepts/settlement): proofs and state updates.
+1. [SNOS](starknet_os) communication. Asks SNOS to process ready blocks and retrieve results.
+1. DA communication. Submits data for [Data Availability Layer](/concepts/data_availability) (currently Ethereum or Starknet).
+1. SL communication. Submits data for [Settlement Layer](/concepts/settlement): proofs and state updates. Monitors the settlement layer for ready proofs.
 
 All of the responsibilities are handled through a individual queues: jobs enter the appropriate queue and are processed in the order they arrived. Possible retries are also managed through the queues.
 

--- a/docs/quickstart/bridge_appchain.md
+++ b/docs/quickstart/bridge_appchain.md
@@ -70,7 +70,7 @@ cast send 0x8a791620dd6260079bf849dc5567adc3f2fdc318 \
  --value 345000001wei
 ```
 
-![Sending assets](/img/pages/bridging-sl-sent.png "Sending assets")
+> ![Sending assets](/img/pages/bridging-sl-sent.png "Sending assets")
 
 The assets should get bridged within about 10 seconds - the time it takes to form a new block.
 
@@ -102,7 +102,7 @@ sncast call \
 --calldata 0xcdef2e5fe47da355316acc78ad8872a2ff9835c52939a62fa83b4d6ee56b3a
 ```
 
-![Sending assets](/img/pages/bridging-appchain-received.png "Sending assets")
+> ![Sending assets](/img/pages/bridging-appchain-received.png "Sending assets")
 
 You should get a response `[0x159, 0x0]`. The first value is `345` in hexadecimal format, the second zero is irrelevant for us.
 

--- a/docs/quickstart/monitor_appchain.md
+++ b/docs/quickstart/monitor_appchain.md
@@ -9,8 +9,8 @@ sidebar_position: 20
 This quick-start guide helps you monitor your local Appchain. Please make sure you are [running a local Appchain](/quickstart/run_appchain) before continuing.
 
 Starting an Appchain launches multiple services. A few notable ones are:
-- Orchestrator
-- Blockchain
+- An [orchestrator](/components/orchestrator)
+- A blockchain
 - Performance monitoring
 
 We will demonstrate how you can query these services to see the status of your Appchain. Note that it may take a few minutes for the Appchain to start gathering data to display.
@@ -21,7 +21,7 @@ The orchestrator utilizes MongoDB database for storing job information.
 
 You can monitor your Appchain by connecting to the database and querying its tables. For this, you should download [MongoDB Compass](https://www.mongodb.com/try/download/compass). Install Compass and connect it to the default address, which should be `mongodb://localhost:27017`.
 
-The database displays four tables. Currently, we're most interested in the orchestrator job entries.
+The connection displays four databases. Currently, we're most interested in the orchestrator database's *jobs* table.
 
 ### Query jobs
 

--- a/docs/quickstart/monitor_appchain.md
+++ b/docs/quickstart/monitor_appchain.md
@@ -31,7 +31,7 @@ The orchestrator is running various jobs all the time. We can query its logs to 
 1. Enter `Sort`: `{ "created_at": -1 }`.
 1. Hit `Find`.
 
-![Latest job](/img/pages/mongodb-latest-job.png "Latest job")
+> ![Latest job](/img/pages/mongodb-latest-job.png "Latest job")
 
 ## Blockchain
 
@@ -76,8 +76,8 @@ curl -X POST http://127.0.0.1:8545 -H "Content-Type: application/json" -d '{
 
 The Appchain utilizes [Grafana](https://grafana.com/) for log and metrics aggregation. We will later add a detailed guide on how to set up Grafana for your Appchain. Meanwhile, here are some examples on what you can monitor.
 
-![Block information](/img/pages/appchain_grafana1.png "Block information")
+> ![Block information](/img/pages/appchain_grafana1.png "Block information")
 *Monitoring block information*
 
-![Measuremenets](/img/pages/appchain_grafana2.png "Measuremenets")
+> ![Measuremenets](/img/pages/appchain_grafana2.png "Measuremenets")
 *Monitoring Appchain performance*

--- a/docs/quickstart/run_appchain.md
+++ b/docs/quickstart/run_appchain.md
@@ -2,7 +2,7 @@
 sidebar_position: 7
 ---
 
-# Run a local appchain
+# Run a local Appchain
 
 ## Overview
 
@@ -36,9 +36,9 @@ cd madara-cli
 
 The above will clone the repository into a new folder and enter it.
 
-### Step 2: Start the runner
+### Step 2: Start the CLI
 
-Next, in the `madara-cli` folder, run the following command to start the Madara runner:
+Next, in the `madara-cli` folder, run the following command to start the Madara Command Line Interface (CLI):
 
 ```bash
 cargo run create
@@ -90,16 +90,12 @@ It will require about 55 blocks (about 10 minutes) for the Appchain to be config
 Congratulations, you now have your own Appchain running!
 
 After running through the guide above, the CLI starts all of the required components automatically. Some of the main components are:
-- Madara [sequencer](/components/nodes). Your node for receiving transactions and building blocks.
-- [Orchestrator](/components/orchestrator). This manages a lot of the communications forward from your sequencer.
-- A prover. This generates (mock) proofs for your blocks.
+- A Madara [sequencer](/components/nodes). Your node for receiving transactions and building blocks.
+- An [orchestrator](/components/orchestrator). This manages a lot of the communications forward from your sequencer.
+- A [prover](/components/prover). This generates (mock) proofs for your blocks.
 - A local Ethereum blockchain for settlement.
 
-To ensure your chain runs properly, it's a good idea to [monitor](/quickstart/monitor_appchain) the Appchain.
-
-## Summary
-
-With the CLI it's easy to start your own Appchain. In the near future, we will post more guides on how to utilize and get familiar with your Appchain.
+Next, you should try [interacting](use_appchain) with your Appchain. Furthermore, to  ensure your chain runs properly, it's a good idea to [monitor](/quickstart/monitor_appchain) the Appchain. 
 
 
 

--- a/docs/quickstart/run_appchain.md
+++ b/docs/quickstart/run_appchain.md
@@ -83,7 +83,7 @@ At the moment, the CLI will automatically set up a new Ethereum chain (with Anvi
 
 It will require about 55 blocks (about 10 minutes) for the Appchain to be configured properly - you should wait for that before interacting with it.
 
-![Appchain is ready](/img/pages/quickstart-appchain-ready.png "Appchain is ready")
+> ![Appchain is ready](/img/pages/quickstart-appchain-ready.png "Appchain is ready")
 
 ### Step 9: Your Appchain is ready
 

--- a/docs/quickstart/run_devnet.md
+++ b/docs/quickstart/run_devnet.md
@@ -8,7 +8,7 @@ sidebar_position: 3
 
 This quick-start guide helps you start your own, local devnet with Madara. 
 
-The chain is lightweight and does not settle its transactions on any underlying chain. Therefore, it does not inherit security from the other chain. If you'd prefer to start an [Appchain](/concepts/appchain) with [settlement](/concepts/settlement), please see [this guide](/quickstart/run_appchain) instead.
+The chain is lightweight and does not settle its transactions on any underlying chain. Therefore, it does not inherit security from another chain. If you'd prefer to start an [Appchain](/concepts/appchain) with [settlement](/concepts/settlement), please see [this guide](/quickstart/run_appchain) instead.
 
 ## Installation
 
@@ -16,7 +16,7 @@ Before continuing, please see the [required tools](/tools) page about installing
 
 ## Install Madara CLI
 
-You should start by installing the main tool for running Madara, the Madara CLI:
+You should next install the main tool for running Madara, the Madara CLI:
 ```bash
 git clone https://github.com/madara-alliance/madara-cli.git
 cd madara-cli
@@ -25,14 +25,14 @@ The above will clone the repository into a new folder and enter it.
 
 ## Run a devnet with Madara CLI
 
-You are now ready to run your own Madara devnet. If you're not in the Madara CLI's folder, go there and run:
+You are now ready to run your own Madara devnet. Execute the following command:
 
 ```bash
 cargo run create
 ```
 The above will prompt you for various options. You should choose the following:
 1. Select Madara mode: `Devnet`.
-1. Input DB path: keep default.
+1. Input DB folder name: keep default.
 
 It may take half an hour to prepare the image for the first time, depending on your system performance. Wait for that to finish.
 

--- a/docs/quickstart/run_devnet.md
+++ b/docs/quickstart/run_devnet.md
@@ -36,6 +36,6 @@ The above will prompt you for various options. You should choose the following:
 
 It may take half an hour to prepare the image for the first time, depending on your system performance. Wait for that to finish.
 
-![Devnet running](/img/pages/quickstart-devnet-start.png "Devnet is running")
+> ![Devnet running](/img/pages/quickstart-devnet-start.png "Devnet is running")
 
 Congratulations, you now have a fully functioning devnet running! Next, you may want to [interact](use_devnet) with the chain.

--- a/docs/quickstart/use_appchain.md
+++ b/docs/quickstart/use_appchain.md
@@ -8,7 +8,7 @@ sidebar_position: 7
 
 This quick-start guide helps you interact with an Appchain. Please make sure you are [running a Madara Appchain](run_appchain) in a separate terminal before continuing.
 
-First, we will prepare an account and then interact with an example contract.
+We will prepare an account and use that to interact with an example contract.
 
 ## Prepare an account
 
@@ -17,9 +17,9 @@ Account creation in Madara, and the [SN Stack](https://www.starknet.io/sn-stack/
 1. Sending assets to the newly created address so the account can be deployed.
 1. Deploying the account from itself.
 
-Since the account must be funded before deployment, you first need to know its address to send assets. The required assets can be bridged from the settlement layer, since we are using an Appchain.
+Since the account must be funded before deployment, you first need to know its address to send assets. Since we are using an Appchain, the required assets can be bridged from the [settlement layer](/concepts/settlement). 
 
-### Create account data
+### Generate account data
 
 First, let's generate the account data.
 
@@ -164,7 +164,7 @@ The required parameters for the command are:
   * This is the default URL.
 * Contract address
   * Used value: `0x021e4332c06c31c764f023f404d6fc2af6f683dbb3e0f258600d7137401fee3a`
-  * The contract address deployed earlier.
+  * The contract address deployed earlier. You may need to change this to reflect the deployment address.
 * Function name
   * Used value: `get`
   * This is the name of the function we are calling inside the example smart contract.
@@ -193,7 +193,7 @@ The required parameters for the command are:
   * This is the default URL.
 * Contract address
   * Used value: `0x021e4332c06c31c764f023f404d6fc2af6f683dbb3e0f258600d7137401fee3a`
-  * The contract address deployed earlier.
+  * The contract address deployed earlier. You may need to change this to reflect the deployment address.
 * Fee token
   * Used value: `eth`
   * Use Appchain version of Eth to pay for transaction fees.

--- a/docs/quickstart/use_appchain.md
+++ b/docs/quickstart/use_appchain.md
@@ -46,7 +46,7 @@ sncast account create --type oz \
 --name account-for-guide --silent
 ```
 
-![Account created](/img/pages/use-appchain-account-created.png "Account created")
+> ![Account created](/img/pages/use-appchain-account-created.png "Account created")
 
 Note the returned account address. You will now need to bridge assets to this address.
 
@@ -78,7 +78,7 @@ The full command is:
 sncast account deploy --url http://127.0.0.1:9945 --name account-for-guide --fee-token eth
 ```
 
-![Account deployed](/img/pages/use-appchain-account-deployed.png "Account deployed")
+> ![Account deployed](/img/pages/use-appchain-account-deployed.png "Account deployed")
 
 ## Contract interaction
 
@@ -114,7 +114,7 @@ The full command is:
 sncast --account account-for-guide declare --url http://localhost:9945 --fee-token eth --contract-name Balance
 ```
 
-![Contract declared](/img/pages/use-appchain-contract-declared.png "Contract declared")
+> ![Contract declared](/img/pages/use-appchain-contract-declared.png "Contract declared")
 
 Note the declared class hash. It may take up to a minute for the declaration to be available in the Appchain.
 
@@ -148,7 +148,7 @@ sncast --account account-for-guide deploy --salt 1 \
 --class-hash 0x041de961fe39bbe6810532bb827b8aae10130262254f8c6ad70e38a565336d90
 ```
 
-![Contract deployed](/img/pages/use-appchain-contract-deployed.png "Contract deployed")
+> ![Contract deployed](/img/pages/use-appchain-contract-deployed.png "Contract deployed")
 
 Note the deployed contract's address.
 

--- a/docs/quickstart/use_devnet.md
+++ b/docs/quickstart/use_devnet.md
@@ -181,4 +181,4 @@ If you now query the balance again, you should see value `8`. Congratulations, y
 
 ## Rerunning this quickstart
 
-If you want to try running this quickstart again you have to change the use `salt` value in contract deployment to anything else - otherwise it will try to deploy to the same address and fail. Furthermore, you can reuse the existing account.
+If you want to try running this quickstart again you have to change the use `salt` value in contract deployment to something else - otherwise it will try to deploy to the same address and fail. Furthermore, you can reuse the existing account.

--- a/docs/quickstart/use_devnet.md
+++ b/docs/quickstart/use_devnet.md
@@ -104,7 +104,9 @@ If needed, remember to replace the following values in the command below:
 ```bash
 sncast account import --type oz --url http://localhost:9944 --silent --address 0x07484e8e3af210b2ead47fa08c96f8d18b616169b350a8b75fe0dc4d2e01d493 --private-key 0x0410c6eadd73918ea90b6658d24f5f2c828e39773819c1443d8602a3c72344c2
 ```
-![Account creation](/img/pages/quickstart-devnet-import.png "Account creation")
+
+> ![Account creation](/img/pages/quickstart-devnet-import.png "Account creation")
+
 Note the imported account name.
 
 :::warning
@@ -128,7 +130,7 @@ If needed, remember to replace the following values in the command below:
 sncast --account account-1 declare --url http://localhost:9944 --contract-name Balance
 ```
 
-![Class hash](/img/pages/quickstart-devnet-classhash.png "Resulting class hash")
+> ![Class hash](/img/pages/quickstart-devnet-classhash.png "Resulting class hash")
 
 Note the declared class hash. It may take up to a minute for the declaration to be available in the blockchain.
 
@@ -144,7 +146,7 @@ If needed, remember to replace the following values in the command below:
 sncast --account account-1 deploy --url http://localhost:9944 --salt 1 --class-hash 0x041de961fe39bbe6810532bb827b8aae10130262254f8c6ad70e38a565336d90
 ```
 
-![Contract address](/img/pages/quickstart-devnet-contract.png "Resulting class contract address")
+> ![Contract address](/img/pages/quickstart-devnet-contract.png "Resulting class contract address")
 
 Note the deployed contract's address.
 


### PR DESCRIPTION
- Add missing links between pages
- Reword some places to make things more fluent
- In Architecture, remove the confusing note about solo chain. This was a misunderstanding and we shouldn't speak about solo chains.
- Add character ">" in front of every image, so they get a unified style. Earlier it was sometimes hard to understand which part is an image and which a text. The "bridging" page gets these changes in a separate PR that adds the L2->L1 bridging (didn't want to cause git conflicts).